### PR TITLE
Ilia challenge

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   smoke-test:
     name: Smoke-test
-    runs-on: ubuntu-latest
+    runs-on: "ubuntu-latest"
     steps:
       - uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,29 @@
+name: "Run smoke tests"
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  smoke-test:
+    name: Smoke-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: nameko-devex
+          environment-file: environment_dev.yml
+          python-version: 3.7
+          auto-update-conda: true
+
+      - name: Checkout repo
+        uses: actions/checkout@v3 
+
+      - name: Run backing services
+        run: ./dev_run_backingsvcs.sh
+
+      - name: Run nameko services
+        run: ./dev_run.sh gateway.service orders.service products.service
+
+      - name: Run smoke test
+        run: ./test/nex-smoketest.sh local
+

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -8,15 +8,15 @@ jobs:
     name: Smoke-test
     runs-on: "ubuntu-latest"
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+ 
       - uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: nameko-devex
           environment-file: environment_dev.yml
           python-version: 3.7
           auto-update-conda: true
-
-      - name: Checkout repo
-        uses: actions/checkout@v3 
 
       - name: Run backing services
         run: ./dev_run_backingsvcs.sh

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ htmlcov
 .DS_Store
 **/*.log
 stats.xml
+**/**init.py
+.idea/

--- a/gateway/gateway/exceptions.py
+++ b/gateway/gateway/exceptions.py
@@ -28,3 +28,13 @@ class OrderNotFound(Exception):
 @remote_error('products.exceptions.NotFound')
 class ProductNotFound(Exception):
     pass
+
+
+@remote_error('products.exceptions.Exists')
+class ProductExists(Exception):
+    pass
+
+
+@remote_error('products.exceptions.Unavailable')
+class ProductUnavailable(Exception):
+    pass

--- a/gateway/gateway/schemas.py
+++ b/gateway/gateway/schemas.py
@@ -1,6 +1,21 @@
 from marshmallow import Schema, fields, post_dump
 
 
+class CreateProductSchema(Schema):
+    id = fields.Str(required=True)
+    title = fields.Str(required=True)
+    maximum_speed = fields.Int(required=True)
+    in_stock = fields.Int(required=True)
+    passenger_capacity = fields.Int(required=True)
+
+
+class UpdateProductSchema(Schema):
+    title = fields.Str(required=False, missing=None)
+    maximum_speed = fields.Int(required=False, missing=None)
+    in_stock = fields.Int(required=False, missing=None)
+    passenger_capacity = fields.Int(required=False, missing=None)
+
+
 class CreateOrderDetailSchema(Schema):
     product_id = fields.Str(required=True)
     price = fields.Decimal(as_string=True, required=True)
@@ -13,14 +28,6 @@ class CreateOrderSchema(Schema):
     )
 
 
-class ProductSchema(Schema):
-    id = fields.Str(required=True)
-    title = fields.Str(required=True)
-    maximum_speed = fields.Int(required=True)
-    in_stock = fields.Int(required=True)
-    passenger_capacity = fields.Int(required=True)
-
-
 class GetOrderSchema(Schema):
     class OrderDetail(Schema):
         id = fields.Int()
@@ -28,7 +35,7 @@ class GetOrderSchema(Schema):
         product_id = fields.Str()
         image = fields.Str()
         price = fields.Decimal(as_string=True)
-        product = fields.Nested(ProductSchema, many=False)
+        product = fields.Nested(CreateProductSchema, many=False)
 
     id = fields.Int()
     order_details = fields.Nested(OrderDetail, many=True)

--- a/gateway/gateway/schemas.py
+++ b/gateway/gateway/schemas.py
@@ -1,4 +1,4 @@
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, post_dump
 
 
 class CreateOrderDetailSchema(Schema):
@@ -22,7 +22,6 @@ class ProductSchema(Schema):
 
 
 class GetOrderSchema(Schema):
-
     class OrderDetail(Schema):
         id = fields.Int()
         quantity = fields.Int()
@@ -33,3 +32,9 @@ class GetOrderSchema(Schema):
 
     id = fields.Int()
     order_details = fields.Nested(OrderDetail, many=True)
+
+    @post_dump(pass_many=True)
+    def wrap_with_count(self, data, many, **kwargs):
+        if many:
+            return {"count": len(data), "data": data}
+        return data

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -74,6 +74,18 @@ class GatewayService(object):
             json.dumps({'id': product_data['id']}), mimetype='application/json'
         )
 
+    @http(
+        "DELETE", "/products/<string:product_id>",
+        expected_exceptions=ProductNotFound
+    )
+    def delete_product(self, request, product_id):
+        """Deletes product by `product_id`
+        """
+
+        self.products_rpc.delete(product_id)
+
+        return Response(json.dumps({'deleted_id': product_id}), mimetype='application/json')
+
     @http("GET", "/orders/<int:order_id>", expected_exceptions=OrderNotFound)
     def get_order(self, request, order_id):
         """Gets the order details for the order given by `order_id`.

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -121,6 +121,16 @@ class GatewayService(object):
 
         return order
 
+    @http("GET", "/orders/all")
+    def list_orders(self, request):
+        """Gets all orders.
+        """
+        orders = self.orders_rpc.list_orders()
+        return Response(
+            GetOrderSchema(many=True).dumps(orders).data,
+            mimetype='application/json'
+        )
+
     @http(
         "POST", "/orders",
         expected_exceptions=(ValidationError, ProductNotFound, BadRequest)

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -123,7 +123,10 @@ class GatewayService(object):
     def list_orders(self, request):
         """Gets all orders.
         """
-        orders = self.orders_rpc.list_orders()
+
+        args = request.args.to_dict()
+        page = args['p'] if 'p' in args else 1
+        orders = self.orders_rpc.list_orders(page)
         return Response(
             GetOrderSchema(many=True).dumps(orders).data,
             mimetype='application/json'

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -1,4 +1,5 @@
 import json
+from http import HTTPStatus
 
 from marshmallow import ValidationError
 from nameko import config
@@ -7,8 +8,8 @@ from nameko.rpc import RpcProxy
 from werkzeug import Response
 
 from gateway.entrypoints import http
-from gateway.exceptions import OrderNotFound, ProductNotFound
-from gateway.schemas import CreateOrderSchema, GetOrderSchema, ProductSchema
+from gateway.exceptions import OrderNotFound, ProductNotFound, ProductExists
+from gateway.schemas import CreateOrderSchema, GetOrderSchema, CreateProductSchema, UpdateProductSchema
 
 
 class GatewayService(object):
@@ -30,13 +31,14 @@ class GatewayService(object):
         """
         product = self.products_rpc.get(product_id)
         return Response(
-            ProductSchema().dumps(product).data,
+            CreateProductSchema().dumps(product).data,
+            status=HTTPStatus.OK,
             mimetype='application/json'
         )
 
     @http(
         "POST", "/products",
-        expected_exceptions=(ValidationError, BadRequest)
+        expected_exceptions=(ValidationError, BadRequest, ProductExists)
     )
     def create_product(self, request):
         """Create a new product - product data is posted as json
@@ -56,9 +58,11 @@ class GatewayService(object):
 
             {"id": "the_odyssey"}
 
+        Throws ProductExists exception when product ID already exists
+
         """
 
-        schema = ProductSchema(strict=True)
+        schema = CreateProductSchema(strict=True)
 
         try:
             # load input data through a schema (for validation)
@@ -71,7 +75,52 @@ class GatewayService(object):
         # Create the product
         self.products_rpc.create(product_data)
         return Response(
-            json.dumps({'id': product_data['id']}), mimetype='application/json'
+            json.dumps({'id': product_data['id']}),
+            status=HTTPStatus.CREATED,
+            mimetype='application/json'
+        )
+
+    @http(
+        "PATCH", "/products/<string:product_id>",
+        expected_exceptions=(ValidationError, BadRequest, ProductNotFound)
+    )
+    def update_product(self, request, product_id):
+        """Updates an existing product - product data is posted as json
+
+        Example request ::
+
+            {
+                "id": "the_odyssey",
+                "title": "The New Odyssey"
+            }
+
+
+        The response contains the updated product ID in a json document ::
+
+            {"id": "the_odyssey"}
+
+        Throws ProductNotFound exception when product doesn't exists
+
+        """
+
+        schema = UpdateProductSchema(strict=True)
+
+        try:
+            # load input data through a schema (for validation)
+            # Note - this may raise `ValueError` for invalid json,
+            # or `ValidationError` if data is invalid.
+            # Note that not all fields are required, only those
+            # that we want to update
+            product_data = schema.loads(request.get_data(as_text=True)).data
+        except ValueError as exc:
+            raise BadRequest("Invalid json: {}".format(exc))
+
+        # Updates the product
+        self.products_rpc.update(product_id, product_data)
+        return Response(
+            json.dumps({'id': product_id}),
+            status=HTTPStatus.OK,
+            mimetype='application/json'
         )
 
     @http(
@@ -84,7 +133,11 @@ class GatewayService(object):
 
         self.products_rpc.delete(product_id)
 
-        return Response(json.dumps({'deleted_id': product_id}), mimetype='application/json')
+        return Response(
+            json.dumps({'deleted_id': product_id}),
+            status=HTTPStatus.OK,
+            mimetype='application/json'
+        )
 
     @http("GET", "/orders/<int:order_id>", expected_exceptions=OrderNotFound)
     def get_order(self, request, order_id):
@@ -96,6 +149,7 @@ class GatewayService(object):
         order = self._get_order(order_id)
         return Response(
             GetOrderSchema().dumps(order).data,
+            status=HTTPStatus.OK,
             mimetype='application/json'
         )
 
@@ -124,11 +178,14 @@ class GatewayService(object):
         """Gets all orders.
         """
 
-        args = request.args.to_dict()
-        page = args['p'] if 'p' in args else 1
-        orders = self.orders_rpc.list_orders(page)
+        # For pagination
+        page = int(request.args.get('p', 1))
+        per_page = int(request.args.get('per_page', 10))
+
+        orders = self.orders_rpc.list_orders(page, per_page)
         return Response(
             GetOrderSchema(many=True).dumps(orders).data,
+            status=HTTPStatus.OK,
             mimetype='application/json'
         )
 
@@ -176,7 +233,10 @@ class GatewayService(object):
         # Create the order
         # Note - this may raise `ProductNotFound`
         id_ = self._create_order(order_data)
-        return Response(json.dumps({'id': id_}), mimetype='application/json')
+        return Response(
+            json.dumps({'id': id_}),
+            status=HTTPStatus.CREATED,
+            mimetype='application/json')
 
     def _create_order(self, order_data):
         # check order product ids are valid

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -105,9 +105,6 @@ class GatewayService(object):
         # raise``OrderNotFound``
         order = self.orders_rpc.get_order(order_id)
 
-        # Retrieve all products from the products service
-        product_map = {prod['id']: prod for prod in self.products_rpc.list()}
-
         # get the configured image root
         image_root = config['PRODUCT_IMAGE_ROOT']
 
@@ -115,7 +112,8 @@ class GatewayService(object):
         for item in order['order_details']:
             product_id = item['product_id']
 
-            item['product'] = product_map[product_id]
+            # Fetch product from storage
+            item['product'] = self.products_rpc.get(product_id)
             # Construct an image url.
             item['image'] = '{}/{}.jpg'.format(image_root, product_id)
 
@@ -179,9 +177,8 @@ class GatewayService(object):
 
     def _create_order(self, order_data):
         # check order product ids are valid
-        valid_product_ids = {prod['id'] for prod in self.products_rpc.list()}
         for item in order_data['order_details']:
-            if item['product_id'] not in valid_product_ids:
+            if not self.products_rpc.exists(item['product_id']):
                 raise ProductNotFound(
                     "Product Id {}".format(item['product_id'])
                 )

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -77,7 +77,7 @@ class TestCreateProduct(object):
                 "title": "The Odyssey"
             })
         )
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert response.json() == {'id': 'the_odyssey'}
         assert gateway_service.products_rpc.create.call_args_list == [call({
                 "in_stock": 10,
@@ -230,7 +230,7 @@ class TestCreateOrder(object):
                 ]
             })
         )
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert response.json() == {'id': 11}
         assert gateway_service.products_rpc.exists.call_args_list == [call('the_odyssey')]
         assert gateway_service.orders_rpc.create_order.call_args_list == [
@@ -366,7 +366,7 @@ class TestListOrders(object):
         assert expected_response == response.json()
 
         # check dependencies called as expected
-        assert [call(1)] == gateway_service.orders_rpc.list_orders.call_args_list
+        assert [call(1, 10)] == gateway_service.orders_rpc.list_orders.call_args_list
 
     def test_empty_list(self, gateway_service, web_session):
         gateway_service.orders_rpc.list_orders.return_value = []

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -130,22 +130,23 @@ class TestGetOrder(object):
         }
 
         # setup mock products-service response:
-        gateway_service.products_rpc.list.return_value = [
-            {
+        products = {
+            'the_odyssey': {
                 'id': 'the_odyssey',
                 'title': 'The Odyssey',
                 'maximum_speed': 3,
                 'in_stock': 899,
                 'passenger_capacity': 100
             },
-            {
+            'the_enigma': {
                 'id': 'the_enigma',
                 'title': 'The Enigma',
                 'maximum_speed': 200,
                 'in_stock': 1,
                 'passenger_capacity': 4
-            },
-        ]
+            }
+        }
+        gateway_service.products_rpc.get.side_effect = lambda prod_id: products[prod_id]
 
         # call the gateway service to get order #1
         response = web_session.get('/orders/1')
@@ -190,7 +191,7 @@ class TestGetOrder(object):
 
         # check dependencies called as expected
         assert [call(1)] == gateway_service.orders_rpc.get_order.call_args_list
-        assert [call()] == gateway_service.products_rpc.list.call_args_list
+        assert [call('the_odyssey'), call('the_enigma')] == gateway_service.products_rpc.get.call_args_list
 
     def test_order_not_found(self, gateway_service, web_session):
         gateway_service.orders_rpc.get_order.side_effect = (
@@ -208,22 +209,7 @@ class TestCreateOrder(object):
 
     def test_can_create_order(self, gateway_service, web_session):
         # setup mock products-service response:
-        gateway_service.products_rpc.list.return_value = [
-            {
-                'id': 'the_odyssey',
-                'title': 'The Odyssey',
-                'maximum_speed': 3,
-                'in_stock': 899,
-                'passenger_capacity': 100
-            },
-            {
-                'id': 'the_enigma',
-                'title': 'The Enigma',
-                'maximum_speed': 200,
-                'in_stock': 1,
-                'passenger_capacity': 4
-            },
-        ]
+        gateway_service.products_rpc.exists.return_value = True
 
         # setup mock create response
         gateway_service.orders_rpc.create_order.return_value = {
@@ -246,7 +232,7 @@ class TestCreateOrder(object):
         )
         assert response.status_code == 200
         assert response.json() == {'id': 11}
-        assert gateway_service.products_rpc.list.call_args_list == [call()]
+        assert gateway_service.products_rpc.exists.call_args_list == [call('the_odyssey')]
         assert gateway_service.orders_rpc.create_order.call_args_list == [
             call([
                 {'product_id': 'the_odyssey', 'quantity': 3, 'price': '41.00'}
@@ -285,22 +271,7 @@ class TestCreateOrder(object):
         self, gateway_service, web_session
     ):
         # setup mock products-service response:
-        gateway_service.products_rpc.list.return_value = [
-            {
-                'id': 'the_odyssey',
-                'title': 'The Odyssey',
-                'maximum_speed': 3,
-                'in_stock': 899,
-                'passenger_capacity': 100
-            },
-            {
-                'id': 'the_enigma',
-                'title': 'The Enigma',
-                'maximum_speed': 200,
-                'in_stock': 1,
-                'passenger_capacity': 4
-            },
-        ]
+        gateway_service.products_rpc.exists.return_value = False
 
         # call the gateway service to create the order
         response = web_session.post(

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -318,3 +318,94 @@ class TestCreateOrder(object):
         assert response.status_code == 404
         assert response.json()['error'] == 'PRODUCT_NOT_FOUND'
         assert response.json()['message'] == 'Product Id unknown'
+
+
+class TestListOrders(object):
+
+    def test_can_list_orders(self, gateway_service, web_session):
+        # setup mock orders-service response:
+        gateway_service.orders_rpc.list_orders.return_value = [
+            {
+                'id': 1,
+                'order_details': [
+                    {
+                        'id': 1,
+                        'quantity': 2,
+                        'product_id': 'the_odyssey',
+                        'price': '200.00'
+                    },
+                    {
+                        'id': 2,
+                        'quantity': 1,
+                        'product_id': 'the_enigma',
+                        'price': '400.00'
+                    }
+                ]
+            },
+            {
+                'id': 2,
+                'order_details': [
+                    {
+                        'id': 2,
+                        'quantity': 3,
+                        'product_id': 'the_enigma',
+                        'price': '400.00'
+                    }
+                ]
+            }
+        ]
+
+        # call the gateway service to get order #1
+        response = web_session.get('/orders/all')
+        assert response.status_code == 200
+
+        expected_response = {
+            "count": 2,
+            "data": [
+                {
+                    'id': 1,
+                    'order_details': [
+                        {
+                            'id': 1,
+                            'quantity': 2,
+                            'product_id': 'the_odyssey',
+                            'price': '200.00'
+                        },
+                        {
+                            'id': 2,
+                            'quantity': 1,
+                            'product_id': 'the_enigma',
+                            'price': '400.00'
+                        }
+                    ]
+                },
+                {
+                    'id': 2,
+                    'order_details': [
+                        {
+                            'id': 2,
+                            'quantity': 3,
+                            'product_id': 'the_enigma',
+                            'price': '400.00'
+                        }
+                    ]
+                }
+            ]
+        }
+        assert expected_response == response.json()
+
+        # check dependencies called as expected
+        assert [call()] == gateway_service.orders_rpc.list_orders.call_args_list
+
+    def test_empty_list(self, gateway_service, web_session):
+        gateway_service.orders_rpc.list_orders.return_value = []
+
+        # call the gateway service to get order #1
+        response = web_session.get('/orders/all')
+        assert response.status_code == 200
+        payload = response.json()
+        expected_response = {
+            "count": 0,
+            "data": []
+        }
+        assert expected_response == payload

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -39,6 +39,32 @@ class TestGetProduct(object):
         assert payload['message'] == 'missing'
 
 
+class TestDeleteProduct(object):
+    def test_can_delete_product(self, gateway_service, web_session):
+        gateway_service.products_rpc.delete.return_value = {
+            "deleted_id": "the_odyssey"
+        }
+        response = web_session.delete('/products/the_odyssey')
+        assert response.status_code == 200
+        assert gateway_service.products_rpc.delete.call_args_list == [
+            call("the_odyssey")
+        ]
+        assert response.json() == {
+            "deleted_id": "the_odyssey"
+        }
+
+    def test_product_not_found(self, gateway_service, web_session):
+        gateway_service.products_rpc.delete.side_effect = (
+            ProductNotFound('missing'))
+
+        # call the gateway service to delete product
+        response = web_session.delete('/products/foo')
+        assert response.status_code == 404
+        payload = response.json()
+        assert payload['error'] == 'PRODUCT_NOT_FOUND'
+        assert payload['message'] == 'missing'
+
+
 class TestCreateProduct(object):
     def test_can_create_product(self, gateway_service, web_session):
         response = web_session.post(

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -366,7 +366,7 @@ class TestListOrders(object):
         assert expected_response == response.json()
 
         # check dependencies called as expected
-        assert [call()] == gateway_service.orders_rpc.list_orders.call_args_list
+        assert [call(1)] == gateway_service.orders_rpc.list_orders.call_args_list
 
     def test_empty_list(self, gateway_service, web_session):
         gateway_service.orders_rpc.list_orders.return_value = []

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -23,6 +23,11 @@ class OrdersService:
         return OrderSchema().dump(order).data
 
     @rpc
+    def list_orders(self):
+        orders = self.db.query(Order).all()
+        return OrderSchema(many=True).dump(orders).data
+
+    @rpc
     def create_order(self, order_details):
         order = Order(
             order_details=[

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -23,12 +23,11 @@ class OrdersService:
         return OrderSchema().dump(order).data
 
     @rpc
-    def list_orders(self, page):
-        # Page 1 is offset 0, page 2 offset 10, etc..
-        offset = (page - 1) * 10
-        ITEMS_PER_PAGE = 10
+    def list_orders(self, page, items_per_page=10):
+        # For 10 items/page, page 1 is offset 0, page 2 offset 10, etc..
+        offset = (page - 1) * items_per_page
 
-        orders = self.db.query(Order).offset(offset).limit(ITEMS_PER_PAGE)
+        orders = self.db.query(Order).offset(offset).limit(items_per_page)
         return OrderSchema(many=True).dump(orders).data
 
     @rpc

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -23,8 +23,12 @@ class OrdersService:
         return OrderSchema().dump(order).data
 
     @rpc
-    def list_orders(self):
-        orders = self.db.query(Order).all()
+    def list_orders(self, page):
+        # Page 1 is offset 0, page 2 offset 10, etc..
+        offset = (page - 1) * 10
+        ITEMS_PER_PAGE = 10
+
+        orders = self.db.query(Order).offset(offset).limit(ITEMS_PER_PAGE)
         return OrderSchema(many=True).dump(orders).data
 
     @rpc

--- a/orders/test/interface/test_service.py
+++ b/orders/test/interface/test_service.py
@@ -41,6 +41,28 @@ def test_will_raise_when_order_not_found(orders_rpc):
     assert err.value.value == 'Order with id 1 not found'
 
 
+def test_list_orders(orders_rpc, order, db_session):
+    order1 = Order()
+    order2 = Order()
+
+    # Reset table, adds orders
+    db_session.query(Order).delete()
+    db_session.add(order1)
+    db_session.add(order2)
+    db_session.commit()
+
+    response = orders_rpc.list_orders()
+    assert len(response) == 2
+    assert response[0]['id'] == order1.id
+    assert response[1]['id'] == order2.id
+
+
+def test_list_orders_when_empty(orders_rpc, order, db_session):
+    db_session.query(Order).delete()
+    db_session.commit()
+    response = orders_rpc.list_orders()
+    assert len(response) == 0
+
 @pytest.mark.usefixtures('db_session')
 def test_can_create_order(orders_service, orders_rpc):
     order_details = [

--- a/orders/test/interface/test_service.py
+++ b/orders/test/interface/test_service.py
@@ -41,7 +41,7 @@ def test_will_raise_when_order_not_found(orders_rpc):
     assert err.value.value == 'Order with id 1 not found'
 
 
-def test_list_orders(orders_rpc, order, db_session):
+def test_list_orders_one_page(orders_rpc, db_session):
     order1 = Order()
     order2 = Order()
 
@@ -51,16 +51,43 @@ def test_list_orders(orders_rpc, order, db_session):
     db_session.add(order2)
     db_session.commit()
 
-    response = orders_rpc.list_orders()
+    response = orders_rpc.list_orders(1)
     assert len(response) == 2
     assert response[0]['id'] == order1.id
     assert response[1]['id'] == order2.id
 
 
+def test_list_orders_two_pages(orders_rpc, db_session):
+    # Reset table
+    db_session.query(Order).delete()
+
+    # Creates orders and add to db
+    orders = []
+    for i in range(0, 16):
+        order = Order()
+        orders.append(order)
+        db_session.add(order)
+
+    # Commit changes
+    db_session.commit()
+
+    # Assert first page
+    response = orders_rpc.list_orders(1)
+    assert len(response) == 10
+    for i in range(0, 9):
+        assert response[i]['id'] == orders[i].id
+
+    # Assert second page
+    response = orders_rpc.list_orders(2)
+    for i in range(10, 16):
+        index = i - 10
+        assert response[index]['id'] == orders[i].id
+
+
 def test_list_orders_when_empty(orders_rpc, order, db_session):
     db_session.query(Order).delete()
     db_session.commit()
-    response = orders_rpc.list_orders()
+    response = orders_rpc.list_orders(1)
     assert len(response) == 0
 
 @pytest.mark.usefixtures('db_session')

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -53,6 +53,14 @@ class StorageWrapper:
             self._format_key(product['id']),
             product)
 
+    def delete(self, product_id):
+        key = self._format_key(product_id)
+        product = self.client.hgetall(key)
+        if not product:
+            raise NotFound('Product ID {} does not exist'.format(product_id))
+        else:
+            self.client.delete(key)
+
     def decrement_stock(self, product_id, amount):
         return self.client.hincrby(
             self._format_key(product_id), 'in_stock', -amount)

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -2,7 +2,7 @@ from nameko import config
 from nameko.extensions import DependencyProvider
 import redis
 
-from products.exceptions import NotFound
+from products.exceptions import NotFound, Exists
 
 
 REDIS_URI_KEY = 'REDIS_URI'
@@ -49,9 +49,20 @@ class StorageWrapper:
             yield self._from_hash(self.client.hgetall(key))
 
     def create(self, product):
+        if self.exists(product['id']):
+            raise Exists('Product ID {} already exist'.format(product['id']))
         self.client.hmset(
             self._format_key(product['id']),
             product)
+
+    def update(self, product_id, product):
+        if not self.exists(product_id):
+            raise NotFound('Product ID {} does not exist'.format(product_id))
+        current_product = self._from_hash(self.client.hgetall(self._format_key(product_id)))
+        current_product.update((k, v) for k, v in product.items() if v is not None)
+        self.client.hmset(
+            self._format_key(product_id),
+            current_product)
 
     def delete(self, product_id):
         key = self._format_key(product_id)

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -61,6 +61,9 @@ class StorageWrapper:
         else:
             self.client.delete(key)
 
+    def exists(self, product_id):
+        return self.client.exists(self._format_key(product_id)) > 0
+
     def decrement_stock(self, product_id, amount):
         return self.client.hincrby(
             self._format_key(product_id), 'in_stock', -amount)

--- a/products/products/exceptions.py
+++ b/products/products/exceptions.py
@@ -1,2 +1,8 @@
 class NotFound(Exception):
     pass
+
+class Exists(Exception):
+    pass
+
+class Unavailable(Exception):
+    pass

--- a/products/products/schemas.py
+++ b/products/products/schemas.py
@@ -7,3 +7,10 @@ class Product(Schema):
     passenger_capacity = fields.Int(required=True)
     maximum_speed = fields.Int(required=True)
     in_stock = fields.Int(required=True)
+
+
+class UpdateProduct(Schema):
+    title = fields.Str(required=False, missing=None)
+    passenger_capacity = fields.Int(required=False, missing=None)
+    maximum_speed = fields.Int(required=False, missing=None)
+    in_stock = fields.Int(required=False, missing=None)

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -30,6 +30,10 @@ class ProductsService:
         product = schemas.Product(strict=True).load(product).data
         self.storage.create(product)
 
+    @rpc
+    def delete(self, product_id):
+        self.storage.delete(product_id)
+
     @event_handler('orders', 'order_created')
     def handle_order_created(self, payload):
         for product in payload['order']['order_details']:

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -31,6 +31,11 @@ class ProductsService:
         self.storage.create(product)
 
     @rpc
+    def update(self, product_id, product):
+        product = schemas.UpdateProduct(strict=True).load(product).data
+        self.storage.update(product_id, product)
+
+    @rpc
     def delete(self, product_id):
         self.storage.delete(product_id)
 

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -34,6 +34,10 @@ class ProductsService:
     def delete(self, product_id):
         self.storage.delete(product_id)
 
+    @rpc
+    def exists(self, product_id):
+        return self.storage.exists(product_id)
+
     @event_handler('orders', 'order_created')
     def handle_order_created(self, payload):
         for product in payload['order']['order_details']:

--- a/products/test/test_dependencies.py
+++ b/products/test/test_dependencies.py
@@ -28,6 +28,19 @@ def test_get(storage, products):
     assert 11 == product['in_stock']
 
 
+def test_delete_fails_on_not_found(storage):
+    with pytest.raises(storage.NotFound) as exc:
+        storage.delete(2)
+    assert 'Product ID 2 does not exist' == exc.value.args[0]
+
+
+def test_delete(storage, products):
+    storage.delete('LZ129')
+    with pytest.raises(storage.NotFound) as exc:
+        storage.delete('LZ129')
+    assert 'Product ID LZ129 does not exist' == exc.value.args[0]
+
+
 def test_list(storage, products):
     listed_products = storage.list()
     assert (

--- a/products/test/test_dependencies.py
+++ b/products/test/test_dependencies.py
@@ -41,6 +41,15 @@ def test_delete(storage, products):
     assert 'Product ID LZ129 does not exist' == exc.value.args[0]
 
 
+def test_exists_true(storage, product):
+    storage.create(product)
+    assert storage.exists(product['id'])
+
+
+def test_exists_false(storage):
+    assert not storage.exists('unknown')
+
+
 def test_list(storage, products):
     listed_products = storage.list()
     assert (

--- a/products/test/test_service.py
+++ b/products/test/test_service.py
@@ -32,6 +32,25 @@ def test_get_product_fails_on_not_found(service_container):
             get(111)
 
 
+def test_delete_product(create_product, service_container):
+
+    stored_product = create_product()
+
+    with entrypoint_hook(service_container, 'delete') as delete:
+        delete(stored_product['id'])
+
+    with pytest.raises(NotFound):
+        with entrypoint_hook(service_container, 'get') as get:
+            get(stored_product['id'])
+
+
+def test_delete_product_fails_on_not_found(service_container):
+
+    with pytest.raises(NotFound):
+        with entrypoint_hook(service_container, 'delete') as get:
+            get(111)
+
+
 def test_list_products(products, service_container):
 
     with entrypoint_hook(service_container, 'list') as list_:

--- a/products/test/test_service.py
+++ b/products/test/test_service.py
@@ -51,6 +51,24 @@ def test_delete_product_fails_on_not_found(service_container):
             get(111)
 
 
+def test_product_exists_true(create_product, service_container):
+
+    stored_product = create_product()
+
+    with entrypoint_hook(service_container, 'exists') as exists:
+        exist_flag = exists(stored_product['id'])
+
+    assert exist_flag
+
+
+def test_product_exists_false(create_product, service_container):
+
+    with entrypoint_hook(service_container, 'exists') as exists:
+        exist_flag = exists('unknown')
+
+    assert not exist_flag
+
+
 def test_list_products(products, service_container):
 
     with entrypoint_hook(service_container, 'list') as list_:

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -42,7 +42,7 @@ scenarios:
         }          
       assert:
       - contains:
-        - 200
+        - 201
         subject: http-code
         not: false
       extract-jsonpath:
@@ -83,7 +83,7 @@ scenarios:
         }
       assert:
       - contains:
-        - 200
+        - 201
         subject: http-code
         not: false
       extract-jsonpath:
@@ -125,7 +125,26 @@ scenarios:
         subject: http-code
         not: false
 
-    # 6. Delete product
+    # 6. Update Product
+    - url: /products/${product_id}
+      label: products-update
+      think-time: uniform(0s, 0s)
+      method: PATCH
+      headers:
+        cache-control: no-cache
+        Content-Type: application/json
+      body: 'request-body-string'
+      body: >
+        {
+          "title": "Some new title"
+        }
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
+
+    # 7. Delete product
     - url: /products/${product_id}
       label: product-delete
       think-time: uniform(0s, 0s)

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -9,6 +9,10 @@ execution:
   ramp-up: 1m
   hold-for: 12h
   scenario: nex
+#- concurrency: 1
+#  ramp-up: 1m
+#  hold-for: 12h
+#  scenario: del
       
 scenarios:
   nex:
@@ -108,7 +112,19 @@ scenarios:
     - if: '"${order_id}" == "NOT_FOUND"'
       then:
         - action: continue
-  
+
+    # 5. Delete product
+    - url: /products/${product_id}
+      label: product-delete
+      think-time: uniform(0s, 0s)
+      method: DELETE
+
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
+
 reporting:
 - module: final-stats
   dump-xml: stats.xml

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -113,17 +113,29 @@ scenarios:
       then:
         - action: continue
 
-    # 5. Delete product
-    - url: /products/${product_id}
-      label: product-delete
+    # 5. List orders
+    - url: /orders/all
+      label: orders-list
       think-time: uniform(0s, 0s)
-      method: DELETE
+      method: GET
 
       assert:
       - contains:
         - 200
         subject: http-code
         not: false
+
+    # 6. Delete product
+    - url: /products/${product_id}
+      label: product-delete
+      think-time: uniform(0s, 0s)
+      method: DELETE
+
+      assert:
+        - contains:
+            - 200
+          subject: http-code
+          not: false
 
 reporting:
 - module: final-stats

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -52,3 +52,7 @@ ID=$(echo ${ORDER_ID} | jq '.id')
 # Test: Get Order back
 echo "=== Getting Order ==="
 curl -s "${STD_APP_URL}/orders/${ID}" | jq .
+
+# Test: Delete Product
+echo "=== Deleting product id: the_odyssey ==="
+curl -s -XDELETE "${STD_APP_URL}/products/the_odyssey" | jq .

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -53,6 +53,10 @@ ID=$(echo ${ORDER_ID} | jq '.id')
 echo "=== Getting Order ==="
 curl -s "${STD_APP_URL}/orders/${ID}" | jq .
 
+# Test: List orders
+echo "=== Listing Orders ==="
+curl -s "${STD_APP_URL}/orders/all" | jq .
+
 # Test: Delete Product
 echo "=== Deleting product id: the_odyssey ==="
 curl -s -XDELETE "${STD_APP_URL}/products/the_odyssey" | jq .

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -57,6 +57,13 @@ curl -s "${STD_APP_URL}/orders/${ID}" | jq .
 echo "=== Listing Orders ==="
 curl -s "${STD_APP_URL}/orders/all" | jq .
 
+# Test: Update Products
+echo "=== Updating  product id: the_odyssey ==="
+curl -s -XPATCH  "${STD_APP_URL}/products/the_odyssey" \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{"title": "The New Odyssey"}' | jq .
+
 # Test: Delete Product
 echo "=== Deleting product id: the_odyssey ==="
 curl -s -XDELETE "${STD_APP_URL}/products/the_odyssey" | jq .


### PR DESCRIPTION
- Enhance product service
  - adds _Delete product rpc call_
  - adds _smoke test_
  - adds _unit test_
  - adds _performance test_

- Enhance order service
  - adds _List order rpc call_(with support for pagination)
  - adds _smoke test_
  - adds _unit test_
  - adds _performance test_

- Fix performance degration issue
  - Order gateway endpoints were loading all products in storage to fetch the order's product details (in the case of `get_order` endpoint), or to validate an order request's product existence (in the case of `create_order` endpoint)
  - The solution is quite simple:
    - on `get_order`: loads each product individually in the order requesting the product through it's ID directly from storage
    - on `create_order`:  checks existence of each product individually requested in the order requesting the product through it's ID directly from storage
  - adjusted unit tests accordingly
____
Regarding performance degradation issue, a comparison below on the performance test before and after the fix. Both orders service endpoints, get and create, execute at a constant time below 30ms, whereas before the fix they approached 500ms at the end of the test.

Before:
![perf-test-degrading-avg-time](https://github.com/Lennon95/nameko-devex/assets/29741995/fcd474a7-3371-4589-90ba-af4cb0a9bc36)

After:
![perf-test-constant-avg-time](https://github.com/Lennon95/nameko-devex/assets/29741995/fccd8e72-d025-4f21-a84d-ccf8d67f84a7)
___
When implementing performance test on `list orders` endpoint, it became clear that the endpoint is only useful if it has at least some basic support for pagination, otherwise a similar problem of degrading performance happens as more orders were added. That's the reason behind a separate commit implementing pagination on the endpoint, instead of implementing the feature in the commit that implemented the endpoint in the first place.
____
Additionally, I've added an `update_order` and adjusted some status code on existing endpoints.